### PR TITLE
Wd 19.brian

### DIFF
--- a/src/components/NewOpportunity/BasicDetails.tsx
+++ b/src/components/NewOpportunity/BasicDetails.tsx
@@ -65,7 +65,7 @@ const BasicDetails = () => {
           label="Virtual"
         />
       </RadioGroup>
-      <h3>Which category do your opportunity fall under?</h3>
+      <h3 id="section-basic-details-category">Which category do your opportunity fall under?</h3>
       <Subtitle>Select up to 3 categories. At least 1 category must be selected.</Subtitle>
       <CategoryGroup />
     </>

--- a/src/components/NewOpportunity/HowToApply.tsx
+++ b/src/components/NewOpportunity/HowToApply.tsx
@@ -49,7 +49,7 @@ const RadioLabel = ({ label, svg }: any) => {
 
 const PrimaryRadio = <Radio color="primary" />;
 
-const HowToApply = () => {
+const HowToApply = (props:any) => {
   const dispatch = useDispatch();
   const {
     opportunity: { type: hostingType, url, type },
@@ -113,6 +113,7 @@ const HowToApply = () => {
                 fullWidth={true}
                 onChange={handleUrlOnChange}
                 value={url}
+                errorMessage={props.isHandleDisplayErrorMsg && !url ? "Please enter the website URL":""}
                 id="opportunity-details-url"
               />
             </div>
@@ -126,6 +127,7 @@ const HowToApply = () => {
 
   return (
     <Section
+      id="section-how-to-apply"
       title="How to apply"
       subtitle="Choose to receive applications through iContribute or redirect
                 volunteers to an external link."

--- a/src/components/NewOpportunity/OpportunityDetails.tsx
+++ b/src/components/NewOpportunity/OpportunityDetails.tsx
@@ -1,5 +1,5 @@
 import { Grid } from "@material-ui/core";
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   updateDescription,

--- a/src/components/NewOpportunity/OpportunityDetails.tsx
+++ b/src/components/NewOpportunity/OpportunityDetails.tsx
@@ -1,5 +1,5 @@
 import { Grid } from "@material-ui/core";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   updateDescription,
@@ -18,8 +18,15 @@ import ShiftCard from "../ShiftCard";
 import Section from "./Section";
 import InputField from "../common/InputField";
 import { HostingType } from "@icontribute-founder/firebase-access";
+import styled from "styled-components";
 
-const OpportunityDetails = ({ setImageUploading }: any) => {
+const ErrorMessage = styled.p`
+  color: #d63334;
+  margin-left: 0px;
+  line-height: 24px;
+`;
+
+const OpportunityDetails = ({ setImageUploading, isHandleDisplayErrorMsg}: any) => {
   const dispatch = useDispatch();
   const {
     opportunity: {
@@ -79,6 +86,7 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
         name="opportunity-details-title"
         id="opportunity-details-title"
         value={eventName}
+        errorMessage={isHandleDisplayErrorMsg && !eventName ?"Please enter the title of the opportunity" : ""}
         // checkMarkVisible={passwordConfirmCheckMark}
         // errorVisible={errorVisible}
         fullWidth
@@ -91,6 +99,7 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
         name="opportunity-details-location"
         id="opportunity-details-location"
         value={address}
+        errorMessage={isHandleDisplayErrorMsg && !address ?"Please enter the location of the opportunity":""}
         fullWidth
         onChange={handleLocationOnChange}
       />
@@ -101,6 +110,7 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
         id="opportunity-details-description"
         onChange={handleDescriptionOnChange}
         value={description}
+        errorMessage={isHandleDisplayErrorMsg && !description ?"Please enter the description of the opportunity":""}
         placeholder="Enter position’s primary duties and responsibilities"
         fullWidth
         rows={8}
@@ -113,6 +123,7 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
         id="opportunity-details-requirements"
         onChange={handleRequirementsOnChange}
         value={requirements}
+        errorMessage={isHandleDisplayErrorMsg && !requirements ?"Please enter the requirements of the opportunity":""}
         placeholder="Enter the necessary requirements"
         fullWidth
         rows={8}
@@ -125,6 +136,7 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
         id="opportunity-details-role"
         onChange={handleRoleOnChange}
         value={role}
+        errorMessage={isHandleDisplayErrorMsg && !role ? "Please enter the primary duties and responsibilities in this opportunity":""}
         placeholder="Enter the possible tasks given"
         fullWidth
         rows={8}
@@ -143,8 +155,9 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
       />
 
       {type !== HostingType.External ? (
-        <div>
+        <div id="section-opportunity-details-shift">
           <h3>Shift</h3>
+          {isHandleDisplayErrorMsg && shift.length===0 ? (<ErrorMessage>Please create at least 1 shift</ErrorMessage>) : ""}
           <Grid container spacing={2}>
             {shift.map((s: Shift, i: number) => (
               <Grid item md={6} key={`grid-shift-${i}`}>
@@ -167,6 +180,7 @@ const OpportunityDetails = ({ setImageUploading }: any) => {
 
   return (
     <Section
+      id="section-opportunity-details"
       title="Opportunity Details"
       subtitle="Let the applicants know more about the open role and their
             primary responsibilities."

--- a/src/components/NewOpportunity/Section.tsx
+++ b/src/components/NewOpportunity/Section.tsx
@@ -5,9 +5,9 @@ const SectionContainer = styled.div`
     margin-bottom: 0px;
 `;
 
-const Section = ({ title, subtitle, content }: any) => {
+const Section = ({id, title, subtitle, content }: any) => {
     return (
-        <SectionContainer>
+        <SectionContainer id={id}>
             <h2>{title}</h2>
             <Subtitle>{subtitle}</Subtitle>
             {content}

--- a/src/components/common/InputField.tsx
+++ b/src/components/common/InputField.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 const Wrapper = styled.div`
     position: relative;
+    margin: 30px 0px;
 `;
 
 interface InputProps {
@@ -31,7 +32,6 @@ const Input = styled.input<InputProps>(
         font-size: 16px;
         color: ${input.color};
         background-color: ${input.backgroundColor.default};
-        margin: 30px 0px;
 
         // &:hover {
         //     background-color: ${input.backgroundColor.hover};
@@ -56,7 +56,7 @@ const TextArea = styled.textarea<InputProps>(
         border-bottom: 1px solid #757575;
         width: ${fullWidth ? "100%" : "auto"};
         height: auto;
-        border: 1px solid #babcbd;
+        border: 1px solid ${hasError ? label.color.error : "#babcbd"};
         box-sizing: border-box;
         border-radius: 8px;
         padding: 18px 18px 15px 15px;
@@ -65,7 +65,6 @@ const TextArea = styled.textarea<InputProps>(
         font-size: 16px;
         color: ${input.color};
         background-color: ${input.backgroundColor.default};
-        margin: 30px 0px;
 
         // &:hover {
         //     background-color: ${input.backgroundColor.hover};

--- a/src/views/AccountSettings.tsx
+++ b/src/views/AccountSettings.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import styled from "styled-components";
 import UploadNewPhoto from "../assets/images/UploadNewPhoto.png";
+import DefaultProfilePhoto from "../assets/images/default_photo.png";
 import InputField from "../components/FormElements/InputField";
 import TextareaField from "../components/FormElements/TextareaField";
 import Button from "../components/common/Button";
@@ -110,7 +111,7 @@ const AccountSettings = () => {
   };
 
   const [currProfilePic, setCurrProfilePic] = useState(
-    userProfile.profilePicture
+    userProfile.profilePicture ? userProfile.profilePicture : DefaultProfilePhoto
   );
 
 

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -177,10 +177,7 @@ const Dashboard = () => {
         <TextGroup style={{ paddingTop: "0px" }}>
           <HeaderTwo>Application details</HeaderTwo>
       {
-        //UNCOMMENT the below statements or use other ways to show opportunity application method (internal or external)
-        //But when variable "type" of Oppotunity (from database) is fixed (which is not "undefined")
-
-        //type === HostingType.External ? (
+        type === HostingType.External ? (
           <Paragraph>
             Through external website (
             <a target="parent" href={"//" + url}>
@@ -188,7 +185,11 @@ const Dashboard = () => {
             </a>
             ){" "}
           </Paragraph>
-        //):("")
+        ):(
+          <Paragraph>
+            Through iContribute Application
+          </Paragraph>
+        )
       }
       </TextGroup>
 

--- a/src/views/Opportunity.tsx
+++ b/src/views/Opportunity.tsx
@@ -68,12 +68,6 @@ const Opportunity = () => {
 
   const [imageUploading, setImageUploading] = useState(false);
 
-  const handleOnClick = (e: any) => {
-    console.log("Event Details: ", e);
-    e.preventDefault();
-    history.push("/new-opportunity-review");
-  };
-
   const {
     opportunity: {
       eventName,
@@ -114,15 +108,42 @@ const Opportunity = () => {
     history.push("/");
   };
 
-  const canSubmit =
-    eventName !== "" &&
-    address !== "" &&
-    requirements !== "" &&
-    role !== "" &&
-    description !== "" &&
-    categories.length > 0 &&
-    ((type !== HostingType.External && shift.length > 0) ||
-      (type === HostingType.External && url !== ""));
+  const [isHandleDisplayErrorMsg, setIsHandleDisplayErrorMsg] = useState(false);
+
+  const handleOnClick = (e: any) => {
+    setIsHandleDisplayErrorMsg(true);
+    if (type === HostingType.External && !url) {
+      const scrollIntoItem = document.getElementById("section-how-to-apply");
+      if (scrollIntoItem) {
+        scrollIntoItem.scrollIntoView();
+      }
+    } else if (categories.length === 0) {
+      const scrollIntoItem = document.getElementById(
+        "section-basic-details-category"
+      );
+      if (scrollIntoItem) {
+        scrollIntoItem.scrollIntoView();
+      }
+    } else if (!eventName || !address || !requirements || !role || !description) {
+      const scrollIntoItem = document.getElementById(
+        "section-opportunity-details"
+      );
+      if (scrollIntoItem) {
+        scrollIntoItem.scrollIntoView();
+      }
+    } else if (type !== HostingType.External && shift.length === 0) {
+      const scrollIntoItem = document.getElementById(
+        "section-opportunity-details-shift"
+      );
+      if (scrollIntoItem) {
+        scrollIntoItem.scrollIntoView();
+      }
+    } else {
+      console.log("Event Details: ", e);
+      e.preventDefault();
+      history.push("/new-opportunity-review");
+    }
+  };
 
   return (
     <StyledOpportunity>
@@ -137,12 +158,15 @@ const Opportunity = () => {
           to find relevant and qualified candidates.
         </Subtitle>
         <ContentContainer>
-          <HowToApply />
+          <HowToApply isHandleDisplayErrorMsg={isHandleDisplayErrorMsg} />
           <BasicDetails />
-          <OpportunityDetails setImageUploading={setImageUploading} />
+          <OpportunityDetails
+            isHandleDisplayErrorMsg={isHandleDisplayErrorMsg}
+            setImageUploading={setImageUploading}
+          />
           <SaveButtonContainer>
             <InteractiveButton
-              disabled={!canSubmit}
+              //disabled={!canSubmit}
               text="Save & Preview"
               onClick={handleOnClick}
             />

--- a/src/views/Opportunity.tsx
+++ b/src/views/Opportunity.tsx
@@ -166,7 +166,6 @@ const Opportunity = () => {
           />
           <SaveButtonContainer>
             <InteractiveButton
-              //disabled={!canSubmit}
               text="Save & Preview"
               onClick={handleOnClick}
             />


### PR DESCRIPTION
## Why ##
Notify user what fields are missing in opportunity page
Show default profile pic in account setting if user doesn't have one
Show application method section in the right side of dashboard page

## What Changed ##
Add new validation, noti and scroll to empty field in op page.
Add default image
Add validation for op event when the method is external

## How I Tested ##
Testing different use cases in op page (enter -> submit, enter -> go back dashboard (or other page) -> go back op page -> submit, ...)
New update is shown in dashboard and account setting page

## What’s Next ## 
N/a

## Link to Ticket/ Bug ##
https://icontribute.notion.site/Save-Preview-Message-e4a7d7b4a4f644f5912950d336ad8101

## Screenshot ##
![image](https://user-images.githubusercontent.com/65921730/147390310-8d69785b-6f00-42ef-b6c9-695d13845649.png)
![image](https://user-images.githubusercontent.com/65921730/147390319-a71ee40d-de6b-48c4-99e9-0aa32856fc71.png)
![image](https://user-images.githubusercontent.com/65921730/147390324-5cb923e4-06a8-4200-abe8-dffcfe85b691.png)
![image](https://user-images.githubusercontent.com/65921730/147390350-cf7f16f3-1a2a-4932-9c88-f8ca27743b92.png)



