### PR TITLE
Wd 22.paulina

### DIFF
--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -29,9 +29,6 @@ const Dashboard = () => {
   const { userProfile } = useSelector((state: RootState) => state.user);
 
   if (opportunities.length > 0) {
-    console.log("Volunteer Oppotunities: ", opportunities);
-    console.log("I AM CALLING THIS 3")
-    //can be updated without this
     dispatch(setExistingOpportunity(opportunities[indexSelected]));
   }
 

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -17,7 +17,6 @@ import {
 import { setAction, setExistingOpportunity } from "../features/opportunity";
 import { HostingType } from "@icontribute-founder/firebase-access";
 
-
 const Dashboard = () => {
   const history = useHistory();
   const dispatch = useDispatch();

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -11,15 +11,12 @@ import EmptyDashboard from "./EmptyDashboard";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../store";
 import {
-  getOpportunities,
   getOpportunitiesByIds,
   selectOpportunity,
 } from "../features/opportunities";
 import { setAction, setExistingOpportunity } from "../features/opportunity";
 import { HostingType } from "@icontribute-founder/firebase-access";
 
-
-import { user } from "../configure";
 
 const Dashboard = () => {
   const history = useHistory();
@@ -48,28 +45,7 @@ const Dashboard = () => {
     dispatch(setAction("create"));
     history.push("/opportunity/create");
   };
-   const handleOnClick2 = async(e:any) => {
-    //console.log("HANDLING CLICK")
-    //dispatch(getOpportunitiesByIds({ eventIds: userProfile.event }));
-    //this gave me James' information for some reasson
-    //dispatch(getOpportunities());
-    
-    //does something but not when i want it to? 
-    //maybe can only work in useEffect
-    ////dispatch(getOpportunitiesByIds({ eventIds: userProfile.event }));
-    //dispatch(setExistingOpportunity(opportunities[indexSelected]));
-
-    e.preventDefault();
-    const new_arr = await user.getCompany(userProfile.email);
-    //new_arr[0] = userProfile.event[0]
-    //new_arr[1] = userProfile.event[1]
-    //userProfile.assign()
-    if (new_arr != null){
-      console.log("WITHIN HANDLE CLICK",userProfile.event)
-      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
-    } 
-    
-  };
+   
 
   const handleCardOnClick = (e: any, i: number, props: any) => {
     dispatch(selectOpportunity(i));
@@ -80,11 +56,7 @@ const Dashboard = () => {
   };
 
   useEffect(() => {
-    console.log("I AM CALLING THIS 2")
-    //if this is not called the opportunities are empty so why can i not call this in a non use effect
-    console.log("WITHIN USE EFFECT",userProfile.event)
     dispatch(getOpportunitiesByIds({ eventIds: userProfile.event }));
-    
   }, []);
 
   if (loading || error !== null) return "";
@@ -161,7 +133,6 @@ const Dashboard = () => {
       </LeftBox>
       <RightBox>
         <Button onClick={handleOnClick}>Create a new opportunity</Button>
-        <Button onClick={handleOnClick2}>Test refresh</Button>
       </RightBox>
     </HeaderContainer>
   );

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -11,11 +11,15 @@ import EmptyDashboard from "./EmptyDashboard";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../store";
 import {
+  getOpportunities,
   getOpportunitiesByIds,
   selectOpportunity,
 } from "../features/opportunities";
 import { setAction, setExistingOpportunity } from "../features/opportunity";
 import { HostingType } from "@icontribute-founder/firebase-access";
+
+
+import { user } from "../configure";
 
 const Dashboard = () => {
   const history = useHistory();
@@ -29,6 +33,8 @@ const Dashboard = () => {
 
   if (opportunities.length > 0) {
     console.log("Volunteer Oppotunities: ", opportunities);
+    console.log("I AM CALLING THIS 3")
+    //can be updated without this
     dispatch(setExistingOpportunity(opportunities[indexSelected]));
   }
 
@@ -42,6 +48,28 @@ const Dashboard = () => {
     dispatch(setAction("create"));
     history.push("/opportunity/create");
   };
+   const handleOnClick2 = async(e:any) => {
+    //console.log("HANDLING CLICK")
+    //dispatch(getOpportunitiesByIds({ eventIds: userProfile.event }));
+    //this gave me James' information for some reasson
+    //dispatch(getOpportunities());
+    
+    //does something but not when i want it to? 
+    //maybe can only work in useEffect
+    ////dispatch(getOpportunitiesByIds({ eventIds: userProfile.event }));
+    //dispatch(setExistingOpportunity(opportunities[indexSelected]));
+
+    e.preventDefault();
+    const new_arr = await user.getCompany(userProfile.email);
+    //new_arr[0] = userProfile.event[0]
+    //new_arr[1] = userProfile.event[1]
+    //userProfile.assign()
+    if (new_arr != null){
+      console.log("WITHIN HANDLE CLICK",userProfile.event)
+      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
+    } 
+    
+  };
 
   const handleCardOnClick = (e: any, i: number, props: any) => {
     dispatch(selectOpportunity(i));
@@ -52,7 +80,11 @@ const Dashboard = () => {
   };
 
   useEffect(() => {
+    console.log("I AM CALLING THIS 2")
+    //if this is not called the opportunities are empty so why can i not call this in a non use effect
+    console.log("WITHIN USE EFFECT",userProfile.event)
     dispatch(getOpportunitiesByIds({ eventIds: userProfile.event }));
+    
   }, []);
 
   if (loading || error !== null) return "";
@@ -129,6 +161,7 @@ const Dashboard = () => {
       </LeftBox>
       <RightBox>
         <Button onClick={handleOnClick}>Create a new opportunity</Button>
+        <Button onClick={handleOnClick2}>Test refresh</Button>
       </RightBox>
     </HeaderContainer>
   );

--- a/src/views/OpportunityConfirmPage.tsx
+++ b/src/views/OpportunityConfirmPage.tsx
@@ -42,7 +42,14 @@ const OpportunityConfirmPage = () => {
     } 
     history.push("/");
   };
-  const handleShareClick = () => {
+  const handleShareClick = async(e:any)=> {
+    e.preventDefault();
+    const new_arr = await user.getCompany(userProfile.email);
+    console.log("THIS IS WITHIN NEW ARRAY",new_arr)
+    if (new_arr != null){
+      console.log("WITHIN HANDLE CLICK",userProfile.event)
+      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
+    } 
     history.push("/");
   };
 

--- a/src/views/OpportunityConfirmPage.tsx
+++ b/src/views/OpportunityConfirmPage.tsx
@@ -4,8 +4,16 @@ import { useHistory } from "react-router-dom";
 import OpportunityCreatedSvg from "../assets/images/opportunityCreated.svg";
 import { BlueButton, LightBlueButton } from "../components/styles";
 import { useState } from "react";
-import { useSelector } from "react-redux";
 import { RootState } from "../store";
+import { useDispatch, useSelector } from "react-redux";
+
+import {
+  getOpportunities,
+  getOpportunitiesByIds,
+  selectOpportunity,
+} from "../features/opportunities";
+
+import { user } from "../configure";
 
 const OpportunityConfirmPage = () => {
   let opportunityDetails = useSelector((state: RootState) => state.opportunity);
@@ -16,8 +24,22 @@ const OpportunityConfirmPage = () => {
     opportunityDetails.opportunity.companyName
   );
 
+ 
+  const { userProfile } = useSelector((state: RootState) => state.user);
+  const userId = userProfile.email;
+  const dispatch = useDispatch();
+
   const history = useHistory();
-  const handleDashboardClick = () => {
+
+
+  const handleDashboardClick = async(e:any) => {
+    e.preventDefault();
+    const new_arr = await user.getCompany(userProfile.email);
+    console.log("THIS IS WITHIN NEW ARRAY",new_arr)
+    if (new_arr != null){
+      console.log("WITHIN HANDLE CLICK",userProfile.event)
+      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
+    } 
     history.push("/");
   };
   const handleShareClick = () => {

--- a/src/views/OpportunityConfirmPage.tsx
+++ b/src/views/OpportunityConfirmPage.tsx
@@ -33,25 +33,20 @@ const OpportunityConfirmPage = () => {
 
 
   const handleDashboardClick = async(e:any) => {
-    e.preventDefault();
-    const new_arr = await user.getCompany(userProfile.email);
-    console.log("THIS IS WITHIN NEW ARRAY",new_arr)
-    if (new_arr != null){
-      console.log("WITHIN HANDLE CLICK",userProfile.event)
-      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
-    } 
+    updateDash();
     history.push("/");
   };
   const handleShareClick = async(e:any)=> {
-    e.preventDefault();
-    const new_arr = await user.getCompany(userProfile.email);
-    console.log("THIS IS WITHIN NEW ARRAY",new_arr)
-    if (new_arr != null){
-      console.log("WITHIN HANDLE CLICK",userProfile.event)
-      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
-    } 
+    updateDash();
     history.push("/");
   };
+
+  const updateDash = async()=> {
+    const new_arr = await user.getCompany(userProfile.email);
+    if (new_arr != null){
+      dispatch(getOpportunitiesByIds({ eventIds: new_arr.event }));
+    } 
+  }
 
   return (
     <Box

--- a/src/views/OpportunityConfirmPage.tsx
+++ b/src/views/OpportunityConfirmPage.tsx
@@ -8,9 +8,7 @@ import { RootState } from "../store";
 import { useDispatch, useSelector } from "react-redux";
 
 import {
-  getOpportunities,
   getOpportunitiesByIds,
-  selectOpportunity,
 } from "../features/opportunities";
 
 import { user } from "../configure";


### PR DESCRIPTION
## Why ##
To allow user to see opportunity they added without having to refresh, less confusion for the user. 

## What Changed ##
Added a function which can get called when the user navigates back to the Dashboard

## How I Tested ##
added opportunities and made sure when navigating back they would appear without having to refresh 

## What’s Next ## 
N/A

## Link to Ticket/ Bug ##
https://icontribute.notion.site/Bug-fix-Refresh-dashboard-redux-for-opportunity-after-creating-a-new-opportunity-High-Priority-f889fed30c5b43f0873065f6f31b44ca

## Screenshot ##
![image](https://user-images.githubusercontent.com/59401667/149042371-8b3af607-ce24-473c-a883-3e23a2416709.png)
![image](https://user-images.githubusercontent.com/59401667/149042398-c0a23308-90bd-47d5-9bc7-f8ee4c984977.png)

