### PR TITLE
resized image

### DIFF
--- a/src/components/Slides.tsx
+++ b/src/components/Slides.tsx
@@ -28,7 +28,7 @@ interface SlideProps {
 }
 
 const Slide = ({ slideItem }: SlideProps) => {
-    return <img src={slideItem.source} alt={slideItem.name} />;
+    return <img src={slideItem.source} alt={slideItem.name} width="90%" height = "90%" />;
 };
 
 const Slides = ({ interval = 5000 }) => {


### PR DESCRIPTION
## Why ##
icontribute logo appears out of bound on login page

## What Changed ##
decreased size of image to make sure logo is visible

## How I Tested ##
works on my current computer but may need to try on another where  display was off

## What’s Next ## 
N/A

## Link to Ticket/ Bug ##
https://www.notion.so/icontribute/Fix-logo-formatting-issue-on-main-page-831424a09de940b68f84f1a8c1c02e3a

## Screenshot ##
![image](https://user-images.githubusercontent.com/59401667/150376687-adeef0d0-2b37-4423-987b-dddfff3fc153.png)

