### PR TITLE
Added links to menu

### DIFF
--- a/src/components/ProfileOptions.tsx
+++ b/src/components/ProfileOptions.tsx
@@ -32,10 +32,12 @@ const ProfileOptions = () => {
   };
 
   const handleHelpCentre = () => {
+    window.location.href = 'https://icontribute.community/#/'
     handleClose();
   };
 
   const handleAbout = () => {
+    window.location.href = 'https://icontribute.community/#/'
     handleClose();
   };
 


### PR DESCRIPTION
Added links to the iContribute home page when Help Centre or About iContribute is clicked.

I could not redirect to the 'Questions?' section of the main page. It will require modification of the main page. An id will have to be added to the 'Questions?' section in the main page.