### PR TITLE
Fix bug, ticket WD-56

### DIFF
--- a/src/components/DeletePopUp.tsx
+++ b/src/components/DeletePopUp.tsx
@@ -30,10 +30,20 @@ const DeletePopUp = ({ handleCancel }: DeletePopUpProps) => {
   };
 
   const handleDeleteOpportunityButtonOnClick = () => {
+    const deletedEventId = opportunities[indexSelected].eventID;
+
+    const newEventIdsAfterDelete = [];
+    for (const op of opportunities){
+      if(op.eventID!==deletedEventId){
+        newEventIdsAfterDelete.push(op.eventID);
+      }
+    }
+
     dispatch(
       deleteOpportunity({
         userProfile,
-        eventId: opportunities[indexSelected].eventID,
+        eventId: deletedEventId,
+        newEventIdsAfterDelete
       })
     );
 

--- a/src/features/opportunities.ts
+++ b/src/features/opportunities.ts
@@ -26,14 +26,13 @@ export const getOpportunitiesByIds = createAsyncThunk<
 
 export const deleteOpportunity = createAsyncThunk<
   any,
-  { userProfile: any; eventId: string },
+  { userProfile: any; eventId: string; newEventIdsAfterDelete:any },
   { rejectValue: any }
 >(
   "opportunity/deleteOpportunity",
-  async ({ userProfile, eventId }, thunkApi) => {
+  async ({ userProfile, eventId, newEventIdsAfterDelete}, thunkApi) => {
     await opportunityCollection.deleteOpportunity(eventId, userProfile.email);
-    const eventIds = userProfile.event.filter((id: string) => id !== eventId);
-    return await opportunityCollection.getOpportunitiesByIds(eventIds);
+    return await opportunityCollection.getOpportunitiesByIds(newEventIdsAfterDelete);
   }
 );
 


### PR DESCRIPTION
## Why ##
The bug can only be seen when you create more than 1 op then delete 1 of those ops.
Dashboard will show all events without the recent-created ones.
However, when refreshing the page, everything will be displayed appropriately.

## What Changed ##
Only the front-end side need to be fixed, database updates correctly
I have changed the delete method under features/opportunities.ts to update dashboard correctly
To update dashboard, instead of getting opportunity ids from UserProfile from user.ts (which will not have the latest update), getting opportunity ids from the opportunities from RootState.

## How I Tested ##
Create 2 ops and delete 1 op.
All ops are displayed appropriately.
Fresh the page to double-check again.

## What’s Next ## 
N/A

## Link to Ticket/ Bug ##
https://icontribute.notion.site/Dashboard-does-not-render-properly-after-deleting-an-opportunity-723dbe46def041998b2e00ebadd6448e

## Screenshot ##
N/A
