### PR TITLE
Open a new tab when clicking About Icontribute

### DIFF
--- a/src/components/ProfileOptions.tsx
+++ b/src/components/ProfileOptions.tsx
@@ -32,7 +32,8 @@ const ProfileOptions = () => {
   };
 
   const handleHelpCentre = () => {
-    window.location.href = 'https://icontribute.community/#/'
+    // window.location.href = 'https://icontribute.community/#/'
+    window.open ('https://icontribute.community/#/');
     handleClose();
   };
 

--- a/src/components/ProfileOptions.tsx
+++ b/src/components/ProfileOptions.tsx
@@ -37,7 +37,7 @@ const ProfileOptions = () => {
   };
 
   const handleAbout = () => {
-    window.location.href = 'https://icontribute.community/#/'
+    window.open ('https://icontribute.community/#/');
     handleClose();
   };
 


### PR DESCRIPTION
## Why ##
Open a new tab when clicking About Icontribute in the header navigation

## What Changed ##
2 line of code change : )

## How I Tested ##
Open a new tab when clicking About Icontribute in the header navigation

## What’s Next ## 
N/A

## Link to Ticket/ Bug ##
https://icontribute.notion.site/Open-About-iContribute-in-a-new-tab-22d8d2838b884b4da8ce72ccf5b95928

## Screenshot ##
N/A
